### PR TITLE
Updating Redux Configuration

### DIFF
--- a/docs/plugin-redux.md
+++ b/docs/plugin-redux.md
@@ -44,7 +44,7 @@ ReactotronConfig, you'll need to add `reactotron-redux` as plugin
 - Reactotron
 + const reactotron = Reactotron
   .configure({ name: 'React Native Demo' })
-  .use(reactotronRedux()) //  <- here i am!
++ .use(reactotronRedux()) //  <- here i am!
   .connect() //Don't forget about me!
   
 + export default reactotron


### PR DESCRIPTION
There wasn't a clear addition of `.use(reactotronRedux())`.  I actually missed it when trying to integrate :/

This should make it a tad more clearer.